### PR TITLE
Add asdf commands to install and set global jdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Work in progess...
 - [x] Install Homebrew and packages from Brewfile
 - [ ] Clean Brewfile
 - [x] Install NodeJS
-- [ ] Install Java
+- [x] Install Java
 - [ ] Change macOS System Preferences
 - [ ] Reconfigure Terminal
 - [ ] Update README with proper instructions

--- a/asdfrc
+++ b/asdfrc
@@ -1,0 +1,1 @@
+java_macos_integration_enable = yes

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -5,6 +5,7 @@
 - clean: ['~']
 
 - link:
+    ~/.asdfrc: asdfrc
     ~/.zshrc: zshrc
     ~/.zshenv: zshenv
     ~/.gitconfig: gitconfig
@@ -20,5 +21,8 @@
       stdout: true
       stderr: true
     - command: ./setup_nodejs.zsh
+      stdout: true
+      stderr: true
+    - command: ./setup_java.zsh
       stdout: true
       stderr: true

--- a/setup_java.zsh
+++ b/setup_java.zsh
@@ -1,0 +1,9 @@
+#!/usr/bin/env zsh
+
+echo "\n=== Starting Java Setup ===\n"
+
+asdf plugin-add java
+asdf install java latest:temurin-8
+asdf install java latest:temurin-11
+asdf install java latest:temurin-17
+asdf global java latest:temurin-17


### PR DESCRIPTION
- Add `setup_java.zsh` with asdf commands to install selected versions of "temurin" JDKs and set one as global.
- Add `asdfrc` with macOS integration variable as per instructions.